### PR TITLE
Update command to support new cask syntax - brew install --cask

### DIFF
--- a/scripts/cask.sh
+++ b/scripts/cask.sh
@@ -10,8 +10,8 @@ echo ""
 ROOT_DIR=$1
 
 echo "installing VSCode"
-brew cask uninstall --force visual-studio-code && brew cask install visual-studio-code
-brew cask uninstall --force visual-studio-code-insiders && brew cask install visual-studio-code-insiders
+brew uninstall --cask --force visual-studio-code && brew install --cask visual-studio-code
+brew uninstall --cask --force visual-studio-code-insiders && brew install --cask visual-studio-code-insiders
 
 if [ -L ~/Library/Application\ Support/Code/user/settings.json ]; then
   echo "found old visual studio code settings. removing..."
@@ -24,35 +24,35 @@ brew tap homebrew/cask-versions
 
 echo "installing custom fonts"
 brew tap homebrew/cask-fonts
-brew cask install font-fira-code
-brew cask install font-oswald
-brew cask install font-ubuntu
+brew install --cask font-fira-code
+brew install --cask font-oswald
+brew install --cask font-ubuntu
 # contentful slide font
-brew cask install font-muli
+brew install --cask font-muli
 
-brew cask install graphql-playground
-brew cask install typora
+brew install --cask graphql-playground
+brew install --cask typora
 
 brew tap jeroenknoops/tap
 brew install gitin
 
-brew cask install qlmarkdown
-brew cask install google-chrome
-brew cask install google-chrome-canary
-brew cask install firefox
-brew cask install firefox-nightly
-brew cask install iterm2
+brew install --cask qlmarkdown
+brew install --cask google-chrome
+brew install --cask google-chrome-canary
+brew install --cask firefox
+brew install --cask firefox-nightly
+brew install --cask iterm2
 # install iterm utilities right away
 curl -L https://iterm2.com/shell_integration/install_shell_integration_and_utilities.sh | bash
 
-brew cask install alfred
-brew cask install wavebox
-brew cask install zoomus
-brew cask install spotify
-brew cask install ngrok
-brew cask install dashlane
-brew cask install bartender
-brew cask install choosy
-brew cask install rocket
-brew cask install monitorcontrol
-brew cask install screenflow
+brew install --cask alfred
+brew install --cask wavebox
+brew install --cask zoomus
+brew install --cask spotify
+brew install --cask ngrok
+brew install --cask dashlane
+brew install --cask bartender
+brew install --cask choosy
+brew install --cask rocket
+brew install --cask monitorcontrol
+brew install --cask screenflow


### PR DESCRIPTION
When I ran `dotfiles install` (running Big Sur), I saw some errors for cask command.

I tried the recommendation of this answer -
https://stackoverflow.com/a/66081492
And it worked like a charm!

This PR include these changes.