### PR TITLE
Remove current branch in git-delete-branch command

### DIFF
--- a/config/.bin/git-delete-branch
+++ b/config/.bin/git-delete-branch
@@ -2,11 +2,10 @@
 
 if [ -z "$1" ]; then
   headline="Current branch: $(git branch --show-current)"
-  branches=$(git for-each-ref --count=30 --sort=-committerdate refs/heads/ --format="%(refname:short)") &&
+  branches=$(git for-each-ref --count=30 --sort=-committerdate refs/heads/ --format="%(refname:short)" | grep --invert-match $(git branch --show-current)) &&
   branch=$(echo "$branches" | fzf --multi --header="$headline") &&
   git branch -D "$(echo "$branch" | sed "s/.* //" | sed "s#remotes/[^/]*/##")"
 else
   git branch -D "$1"
   git push origin --delete "$1"
 fi
-


### PR DESCRIPTION
Because we don't want to/cannot remove the branch we are on
`git branch --show-current` can only be used for git 2.22 users.
If we want better compatibility, we can use `git rev-parse --abbrev-ref HEAD` instead.
[https://stackoverflow.com/a/6245587/12444184](https://stackoverflow.com/a/6245587/12444184)
Because you already use `git branch -show-current` for the headline, I reuse this one.

By the way, I'm not sure using `git for-each-ref` command for listing branches is a good idea.
When initiating a project, if we create branches from the first branch that does not yet contain commits, they are not listed. I'm aware that this should almost never happen, I just think you should be aware that there may be cases where branches are not listed by fzf.

If you are interested, I found the grep tip on this [article](https://seb.jambor.dev/posts/improving-shell-workflows-with-fzf/) (and a lot of other things !).

Also, since we using `git for-each-ref` and not `git branch -a`, are we sure the `sed` commands are used? Because on my tests I never get `remotes/...` etc